### PR TITLE
Introduce the `Key` trait to support other key sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,14 @@
 [package]
 name = "obkv"
 version = "0.1.1"
-
 description = "One-byte key and a value store"
 repository = "https://github.com/Kerollmops/obkv"
 documentation = "https://docs.rs/obkv"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 license = "MIT"
-
 categories = ["encoding", "database-implementations"]
 keywords = ["lightweight", "key-value-store", "minimalist"]
-
 edition = "2018"
-
-[dependencies]
-bytemuck = "1.5.1"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ keywords = ["lightweight", "key-value-store", "minimalist"]
 
 edition = "2018"
 
+[dependencies]
+bytemuck = "1.5.1"
+
 [dev-dependencies]
 quickcheck = "0.9.2"


### PR DESCRIPTION
This PR makes the library generic on the key types that can be used to encode an obkv on disk, it introduces the new `Key` trait that represents any type of key that can be used by the `obkv` library to encode keys in bytes.

```rust
use obkv::{KvWriterU16, KvReaderU16}; // those are simple aliases

let mut writer = KvWriterU16::memory();
writer.insert(0, b"hello").unwrap();
writer.insert(1, b"blue").unwrap();
writer.insert(255, b"world").unwrap();

let obkv = writer.into_inner().unwrap();
let mut iter = KvReaderU16::new(&obkv).iter();
assert_eq!(iter.next(), Some((0, &b"hello"[..])));
assert_eq!(iter.next(), Some((1, &b"blue"[..])));
assert_eq!(iter.next(), Some((255, &b"world"[..])));
assert_eq!(iter.next(), None);
```