### PR TITLE
Various Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obkv"
-version = "0.2.2"
+version = "0.3.0"
 description = "Optimized-bytes key and a value store"
 repository = "https://github.com/Kerollmops/obkv"
 documentation = "https://docs.rs/obkv"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,19 @@ pub struct KvReader<K> {
 }
 
 impl<K> KvReader<K> {
+    /// Construct a reader on top of a memory area.
+    ///
+    /// ```
+    /// use obkv::KvReaderU16;
+    ///
+    /// let reader = KvReaderU16::from_slice(&[][..]);
+    /// let mut iter = reader.iter();
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn from_slice(bytes: &[u8]) -> &KvReader<K> {
+        bytes.into()
+    }
+
     /// Returns the value associated with the given key
     /// or `None` if the key is not present.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,9 +292,14 @@ impl<K> KvReader<K> {
         .fuse()
     }
 
-    /// Converts a KvReader to a byte slice.
+    /// Converts a [`KvReader`] to a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
+    }
+
+    /// Converts a [`KvReader`] to a boxed `KvReader`.
+    pub fn boxed(&self) -> Box<Self> {
+        self.as_bytes().to_vec().into_boxed_slice().into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@
 //! writer.insert(255, b"world").unwrap();
 //! let obkv = writer.into_inner().unwrap();
 //!
-//! let mut iter = KvReaderU16::new(&obkv).iter();
+//! let reader: &KvReaderU16 = obkv[..].into();
+//! let mut iter = reader.iter();
 //! assert_eq!(iter.next(), Some((0, &b"hello"[..])));
 //! assert_eq!(iter.next(), Some((1, &b"blue"[..])));
 //! assert_eq!(iter.next(), Some((255, &b"world"[..])));
@@ -35,6 +36,7 @@ use std::convert::{TryFrom, TryInto};
 use std::io::{self, Error, ErrorKind::Other};
 use std::iter::Fuse;
 use std::marker::PhantomData;
+use std::mem;
 
 use self::varint::{varint_decode32, varint_encode32};
 
@@ -48,13 +50,13 @@ pub type KvWriterU32<W> = KvWriter<W, u32>;
 pub type KvWriterU64<W> = KvWriter<W, u64>;
 
 /// A reader that can read `obkv`s with `u8` keys.
-pub type KvReaderU8<'a> = KvReader<'a, u8>;
+pub type KvReaderU8 = KvReader<u8>;
 /// A reader that can read `obkv`s with `u16` keys.
-pub type KvReaderU16<'a> = KvReader<'a, u16>;
+pub type KvReaderU16 = KvReader<u16>;
 /// A reader that can read `obkv`s with `u32` keys.
-pub type KvReaderU32<'a> = KvReader<'a, u32>;
+pub type KvReaderU32 = KvReader<u32>;
 /// A reader that can read `obkv`s with `u64` keys.
-pub type KvReaderU64<'a> = KvReader<'a, u64>;
+pub type KvReaderU64 = KvReader<u64>;
 
 /// An `obkv` database writer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -181,28 +183,14 @@ impl<W: io::Write, K: Key + PartialOrd> KvWriter<W, K> {
 }
 
 /// A reader of `obkv` databases.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KvReader<'a, K> {
-    bytes: &'a [u8],
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct KvReader<K> {
     _phantom: PhantomData<K>,
+    bytes: [u8],
 }
 
-impl<'a, K> KvReader<'a, K> {
-    /// Construct a reader on top of a memory area.
-    ///
-    /// ```
-    /// use obkv::KvReaderU16;
-    ///
-    /// let mut iter = KvReaderU16::new(&[]).iter();
-    /// assert_eq!(iter.next(), None);
-    /// ```
-    pub fn new(bytes: &[u8]) -> KvReader<K> {
-        KvReader {
-            bytes,
-            _phantom: PhantomData,
-        }
-    }
-
+impl<K> KvReader<K> {
     /// Returns the value associated with the given key
     /// or `None` if the key is not present.
     ///
@@ -215,13 +203,13 @@ impl<'a, K> KvReader<'a, K> {
     /// writer.insert(255, b"world").unwrap();
     /// let obkv = writer.into_inner().unwrap();
     ///
-    /// let reader = KvReaderU16::new(&obkv);
+    /// let reader: &KvReaderU16 = obkv[..].into();
     /// assert_eq!(reader.get(0), Some(&b"hello"[..]));
     /// assert_eq!(reader.get(1), Some(&b"blue"[..]));
     /// assert_eq!(reader.get(10), None);
     /// assert_eq!(reader.get(255), Some(&b"world"[..]));
     /// ```
-    pub fn get(&self, requested_key: K) -> Option<&'a [u8]>
+    pub fn get(&self, requested_key: K) -> Option<&[u8]>
     where
         K: Key + PartialOrd,
     {
@@ -242,32 +230,63 @@ impl<'a, K> KvReader<'a, K> {
     /// writer.insert(255, b"world").unwrap();
     /// let obkv = writer.into_inner().unwrap();
     ///
-    /// let mut iter = KvReaderU16::new(&obkv).iter();
+    /// let reader: &KvReaderU16 = obkv[..].into();
+    /// let mut iter = reader.iter();
     /// assert_eq!(iter.next(), Some((0, &b"hello"[..])));
     /// assert_eq!(iter.next(), Some((1, &b"blue"[..])));
     /// assert_eq!(iter.next(), Some((255, &b"world"[..])));
     /// assert_eq!(iter.next(), None);
     /// assert_eq!(iter.next(), None); // is it fused?
     /// ```
-    pub fn iter(&self) -> Fuse<KvIter<'a, K>>
+    pub fn iter(&self) -> Fuse<KvIter<'_, K>>
     where
         K: Key,
     {
         KvIter {
-            bytes: self.bytes,
-            offset: 0,
             _phantom: PhantomData,
+            offset: 0,
+            bytes: self.as_bytes(),
         }
         .fuse()
     }
 
     /// Converts a KvReader to a byte slice.
-    pub fn as_bytes(&self) -> &'a [u8] {
-        self.bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
     }
 }
 
-impl<'a, K: Key> IntoIterator for KvReader<'a, K> {
+/// Construct a reader on top of a memory area.
+///
+/// ```
+/// use obkv::KvReaderU16;
+///
+/// let reader: Box<KvReaderU16> = Vec::new().into_boxed_slice().into();
+/// let mut iter = reader.iter();
+/// assert_eq!(iter.next(), None);
+/// ```
+impl<K> From<Box<[u8]>> for Box<KvReader<K>> {
+    fn from(boxed_bytes: Box<[u8]>) -> Self {
+        unsafe { mem::transmute(boxed_bytes) }
+    }
+}
+
+/// Construct a reader on top of a memory area.
+///
+/// ```
+/// use obkv::KvReaderU16;
+///
+/// let reader: &KvReaderU16 = [][..].into();
+/// let mut iter = reader.iter();
+/// assert_eq!(iter.next(), None);
+/// ```
+impl<'a, K> From<&'a [u8]> for &'a KvReader<K> {
+    fn from(bytes: &'a [u8]) -> Self {
+        unsafe { mem::transmute(bytes) }
+    }
+}
+
+impl<'a, K: Key> IntoIterator for &'a KvReader<K> {
     type Item = (K, &'a [u8]);
     type IntoIter = Fuse<KvIter<'a, K>>;
 
@@ -279,9 +298,9 @@ impl<'a, K: Key> IntoIterator for KvReader<'a, K> {
 /// An iterator over a `obkv` database.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct KvIter<'a, K> {
-    bytes: &'a [u8],
-    offset: usize,
     _phantom: PhantomData<K>,
+    offset: usize,
+    bytes: &'a [u8],
 }
 
 impl<'a, K: Key> Iterator for KvIter<'a, K> {
@@ -341,3 +360,26 @@ macro_rules! impl_key {
 }
 
 impl_key!(u8, u16, u32, u64);
+
+#[cfg(test)]
+mod test {
+    use crate::{KvReaderU8, KvWriterU8};
+
+    fn reinterpret_box_u8_to_kvreader(boxed_bytes: Box<[u8]>) -> Box<KvReaderU8> {
+        // Ensure the conversion from Box<[u8]> to Box<KvReader>
+        unsafe { std::mem::transmute(boxed_bytes) }
+    }
+
+    // You can construct an obkv and store the KvReader in owned memory.
+    #[test]
+    fn owned_kvreader() {
+        let mut writer = KvWriterU8::memory();
+        writer.insert(1, "hello").unwrap();
+        writer.insert(10, "world").unwrap();
+        writer.insert(20, "poupoupidoup").unwrap();
+        let buffer = writer.into_inner().unwrap();
+
+        let boxed = buffer.into_boxed_slice();
+        let _boxed: Box<KvReaderU8> = reinterpret_box_u8_to_kvreader(boxed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,12 @@ impl<K> From<Box<[u8]>> for Box<KvReader<K>> {
     }
 }
 
+impl<K> From<Box<KvReader<K>>> for Box<[u8]> {
+    fn from(boxed_bytes: Box<KvReader<K>>) -> Self {
+        unsafe { mem::transmute(boxed_bytes) }
+    }
+}
+
 /// Construct a reader on top of a memory area.
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,11 @@ impl<K> KvWriter<Vec<u8>, K> {
             writer: Vec::new(),
         }
     }
+
+    /// Converts a `KvWriter` into a boxed `KvReader`.
+    pub fn into_boxed(self) -> Box<KvReader<K>> {
+        self.writer.into_boxed_slice().into()
+    }
 }
 
 impl<W, K> KvWriter<W, K> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,13 @@ impl<W: io::Write, K: Key + PartialOrd> KvWriter<W, K> {
 }
 
 impl<K: Key + PartialOrd> KvWriter<Vec<u8>, K> {
-    // TODO find a better name
-    pub fn lazy_insert<F>(&mut self, key: K, val_length: u32, val_serialize: F) -> io::Result<()>
+    /// Insert a new entry and prepare a buffer to write into.
+    pub fn reserved_insert<F>(
+        &mut self,
+        key: K,
+        val_length: u32,
+        val_serialize: F,
+    ) -> io::Result<()>
     where
         F: FnOnce(&mut [u8]) -> io::Result<()>,
     {


### PR DESCRIPTION
This PR modifies the `KvReader` to be unsized and interprets `&'a [u8]` as `&'a KvReader` (instead of `KvReader<'a>`), which makes it easier to use in Rust but introduces unsafe. It also bumps the version to v0.3.0 and introduces a new method to directly write a value into the `KvWriter<Vec<u8>, _>` when the size is known, e.g., `RoaringBitmaps`.

Also bumps the version to v0.3.0.